### PR TITLE
correct banner parsing and omit timestamp in cmd call for legacy devices

### DIFF
--- a/pyEOS/config.py
+++ b/pyEOS/config.py
@@ -42,13 +42,24 @@ class EOSConf:
         cmds = OrderedDict()
         prev_key = None
         separator = ' '
+        banner = False
+        banner_txt = ''
 
         if isinstance(config, unicode) or isinstance(config, str):
             config = config.splitlines()
 
         for line in config:
             line = line.strip('\n')
+
             if line.strip() == '' or line.startswith('!'):
+                pass
+            elif line.startswith('EOF'):
+                banner = False
+                banner_txt += line
+                pass
+            elif line.startswith('banner motd') or banner is True:
+                banner = True
+                banner_txt += line
                 pass
             elif line.startswith('      '):
                 cmds[prev_key]['cmds'][sub_prev_key]['cmds'][line.strip()] = None

--- a/pyEOS/config.py
+++ b/pyEOS/config.py
@@ -56,11 +56,9 @@ class EOSConf:
             elif line.startswith('EOF'):
                 banner = False
                 banner_txt += line
-                pass
             elif line.startswith('banner motd') or banner is True:
                 banner = True
                 banner_txt += line
-                pass
             elif line.startswith('      '):
                 cmds[prev_key]['cmds'][sub_prev_key]['cmds'][line.strip()] = None
             elif line.startswith('   '):

--- a/pyEOS/eos.py
+++ b/pyEOS/eos.py
@@ -105,6 +105,13 @@ class EOS:
                     )
                 else:
                     raise exceptions.CommandUnconverted(error)
+            # code -32602 means "Unexpected parameter 'timestamps' for method 'runCmds' provided"
+            elif code == -32602:
+                result = self.device.runCmds(
+                    version=version,
+                    cmds=commands,
+                    format=format
+                )
             elif code == 1002:
                 raise exceptions.CommandError(error)
             else:


### PR DESCRIPTION
Some initial changes while trying to make this work for me... 
- The config parser was tripping on the banner. I am parsing that properly now and collecting it in a single variable "banner_txt". Not quite sure where to add it to the structure. Any suggestions? 
- My older EOS doesn't support the "timestamps" parameter in the API call. Catching and re-trying the same way you did with the output format (nice!), I just hope -32602 doesn't also mean something else... 
- What's up with those missing newlines at the end of the file? 
